### PR TITLE
[Not needed?] Modify the permission system

### DIFF
--- a/pkg/api/dashboard_permission.go
+++ b/pkg/api/dashboard_permission.go
@@ -126,6 +126,10 @@ func (hs *HTTPServer) UpdateDashboardPermissions(c *models.ReqContext) response.
 				return response.Error(400, err.Error(), err)
 			}
 
+			if err == guardian.ErrGuardianOverrideDuplicate {
+				return response.Error(409, err.Error(), err)
+			}
+
 			return response.Error(500, "Error while checking dashboard permissions", err)
 		}
 

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -201,6 +201,8 @@ func (d *DashboardStore) UpdateDashboardACL(ctx context.Context, dashboardID int
 			return fmt.Errorf("deleting from dashboard_acl failed: %w", err)
 		}
 
+		hasAcl := false
+
 		for _, item := range items {
 			if item.UserID == 0 && item.TeamID == 0 && (item.Role == nil || !item.Role.IsValid()) {
 				return models.ErrDashboardAclInfoMissing
@@ -214,10 +216,12 @@ func (d *DashboardStore) UpdateDashboardACL(ctx context.Context, dashboardID int
 			if _, err := sess.Insert(item); err != nil {
 				return err
 			}
+
+			hasAcl = true
 		}
 
 		// Update dashboard HasAcl flag
-		dashboard := models.Dashboard{HasAcl: true}
+		dashboard := models.Dashboard{HasAcl: hasAcl}
 		_, err = sess.Cols("has_acl").Where("id=?", dashboardID).Update(&dashboard)
 		return err
 	})

--- a/pkg/services/guardian/guardian.go
+++ b/pkg/services/guardian/guardian.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	ErrGuardianPermissionExists = errors.New("permission already exists")
-	ErrGuardianOverride         = errors.New("you can only override a permission to be higher")
+	ErrGuardianPermissionExists  = errors.New("permission already exists")
+	ErrGuardianOverride          = errors.New("you can only override a permission to be higher")
+	ErrGuardianOverrideDuplicate = errors.New("you can not override with duplicate permissions")
 )
 
 // DashboardGuardian to be used for guard against operations without access on dashboard and acl
@@ -205,9 +206,15 @@ func (g *dashboardGuardianImpl) CheckPermissionBeforeUpdate(permission models.Pe
 				continue
 			}
 
-			if a.IsDuplicateOf(existingPerm) && a.Permission <= existingPerm.Permission {
-				return false, ErrGuardianOverride
+			if a.IsDuplicateOf(existingPerm) {
+				return false, ErrGuardianOverrideDuplicate
 			}
+			// Disabling the following check because it goes against the way we are using permissions https://soracom.slack.com/archives/C9PHDH1QB/p1555664739066900
+			// existing permissions returned by GetAcl above include default parent folder permissions if this dashboard has never had permissions set before
+			// and is inside a folder.  That could possibly cause an error _before_ we are able to set the permissions catch 22.
+			// if a.Permission <= existingPerm.Permission {
+			// 	return false, ErrGuardianOverride
+			// }
 		}
 	}
 


### PR DESCRIPTION
Lagoon 2 changes to allow restricting Viewers to individual dashboards while still allowing them to access folders.

These changes are no longer effective now that RBAC (Role based access control) is now the default in OSS grafana unless we disable it.

We may adopt the `editors_can_admin` flag and allow users to manage permissions directly from inside grafana.
