### PR TITLE
Filter users in the permission list

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -167,18 +167,14 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *models.ReqContext) respo
 		})
 	}
 
-	if !c.SignedInUser.IsGrafanaAdmin {
-		result = filterAdminUsers(result)
-	}
-
 	return response.JSON(http.StatusOK, result)
 }
 
-func filterAdminUsers(inDTOs []*dtos.UserLookupDTO) []*dtos.UserLookupDTO {
+func filterAdminUsers(inDTOs []*org.OrgUserDTO) []*org.OrgUserDTO {
 
-	outDTOs := make([]*dtos.UserLookupDTO, 0)
+	outDTOs := make([]*org.OrgUserDTO, 0)
 	for _, dto := range inDTOs {
-		if isSoracomAdminUser(dto.Login) {
+		if isSoracomAdminUser(dto.Login) || dto.Role == "Admin" {
 			continue
 		}
 		outDTOs = append(outDTOs, dto)
@@ -258,6 +254,10 @@ func (hs *HTTPServer) getOrgUsersHelper(c *models.ReqContext, query *org.GetOrgU
 		for i := range filteredUsers {
 			filteredUsers[i].AccessControl = accessControlMetadata[fmt.Sprint(filteredUsers[i].UserID)]
 		}
+	}
+
+	if !c.SignedInUser.IsGrafanaAdmin {
+		filteredUsers = filterAdminUsers(filteredUsers)
 	}
 
 	return filteredUsers, nil

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -165,7 +167,36 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *models.ReqContext) respo
 		})
 	}
 
+	if !c.SignedInUser.IsGrafanaAdmin {
+		result = filterAdminUsers(result)
+	}
+
 	return response.JSON(http.StatusOK, result)
+}
+
+func filterAdminUsers(inDTOs []*dtos.UserLookupDTO) []*dtos.UserLookupDTO {
+
+	outDTOs := make([]*dtos.UserLookupDTO, 0)
+	for _, dto := range inDTOs {
+		if isSoracomAdminUser(dto.Login) {
+			continue
+		}
+		outDTOs = append(outDTOs, dto)
+	}
+	return outDTOs
+}
+
+var adminUsers = os.Getenv("LAGOON_ADMIN_USERNAMES")
+
+func isSoracomAdminUser(user string) bool {
+	users := strings.Split(adminUsers, ",")
+
+	for _, adminName := range users {
+		if user == adminName {
+			return true
+		}
+	}
+	return false
 }
 
 // swagger:route GET /orgs/{org_id}/users orgs getOrgUsers

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -3,7 +3,9 @@ package resourcepermissions
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -129,7 +131,37 @@ func (a *api) getPermissions(c *models.ReqContext) response.Response {
 		}
 	}
 
+	if !c.SignedInUser.IsGrafanaAdmin {
+		dto = filterAdminUsers(dto)
+	}
+
+	//need to add a filter here
 	return response.JSON(http.StatusOK, dto)
+}
+
+func filterAdminUsers(inDTOs []resourcePermissionDTO) []resourcePermissionDTO {
+
+	outDTOs := []resourcePermissionDTO{}
+	for _, dto := range inDTOs {
+		if dto.BuiltInRole == "Admin" || isSoracomAdminUser(dto.UserLogin) {
+			continue
+		}
+		outDTOs = append(outDTOs, dto)
+	}
+	return outDTOs
+}
+
+var adminUsers = os.Getenv("LAGOON_ADMIN_USERNAMES")
+
+func isSoracomAdminUser(user string) bool {
+	users := strings.Split(adminUsers, ",")
+
+	for _, adminName := range users {
+		if user == adminName {
+			return true
+		}
+	}
+	return false
 }
 
 type setPermissionCommand struct {


### PR DESCRIPTION
This PR removes any "Admin" users (and Builtin Admin Roles) from appearing in the permissions list when accessed by a non-admin user.

Admin usernames can be defined by environment variable as a comma separated string 
`export LAGOON_ADMIN_USERNAMES=admin,some-other-admin-name,another-admin` etc...