### PR TITLE
Add ability to disable alert execution with label

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -463,7 +463,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 				query.ResultFoldersTitles[folder.Uid] = folder.Title
 			}
 		}
-		fmt.Println("Alerts found:", len(rules), " Folders:", len(folders))
+		st.Logger.Info("Alerts found for processing", "numAlerts", len(rules), "numFolders", len(folders))
 		return nil
 	})
 }


### PR DESCRIPTION
Adding a label `ALERT_DISABLED` to an alert rule will stop it from being scheduled for execution.  