### PR TITLE
Make join by field the default

### DIFF
--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -55,7 +55,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      selectedDataFrame: 0,
+      selectedDataFrame: DataTransformerID.joinByField,
       dataFrameIndex: 0,
       transformId: DataTransformerID.noop,
       transformationOptions: buildTransformationOptions(),


### PR DESCRIPTION
https://app.shortcut.com/soracom/story/91611/make-series-joined-by-time-default-in-lagoon-csv-export

Make `Series joined by time` default in Lagoon CSV export

When you click a Panel and choose [Inspect] > [Data], the default Data option is not Series joined by time which can export all columns in the CSV. Please make it a default option to make downloading CSV easier.

![image](https://github.com/soracom/grafana/assets/2775919/73b970df-d324-4a02-94ee-d40a12f4a982)
