### PR TITLE
Permission fix deleting dashboards with same UID

### DIFF
--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -805,15 +805,14 @@ func (d *DashboardStore) deleteDashboard(cmd *models.DeleteDashboardCommand, ses
 		}
 
 		// remove all access control permission with folder scope
-		_, err = sess.Exec("DELETE FROM permission WHERE scope = ?", dashboards.ScopeFoldersProvider.GetResourceScopeUID(dashboard.Uid))
+		err = d.deleteResourcePermissions(sess, dashboard.OrgId, dashboards.ScopeFoldersProvider.GetResourceScopeUID(dashboard.Uid))
 		if err != nil {
 			return err
 		}
 
 		for _, dash := range dashIds {
 			// remove all access control permission with child dashboard scopes
-			_, err = sess.Exec("DELETE FROM permission WHERE scope = ?", ac.GetResourceScopeUID("dashboards", dash.Uid))
-			if err != nil {
+			if err := d.deleteResourcePermissions(sess, dashboard.OrgId, ac.GetResourceScopeUID("dashboards", dash.Uid)); err != nil {
 				return err
 			}
 		}
@@ -860,8 +859,7 @@ func (d *DashboardStore) deleteDashboard(cmd *models.DeleteDashboardCommand, ses
 			}
 		}
 	} else {
-		_, err = sess.Exec("DELETE FROM permission WHERE scope = ?", ac.GetResourceScopeUID("dashboards", dashboard.Uid))
-		if err != nil {
+		if err := d.deleteResourcePermissions(sess, dashboard.OrgId, ac.GetResourceScopeUID("dashboards", dashboard.Uid)); err != nil {
 			return err
 		}
 	}
@@ -884,6 +882,24 @@ func (d *DashboardStore) deleteDashboard(cmd *models.DeleteDashboardCommand, ses
 		}
 	}
 	return nil
+}
+
+// Backport of https://github.com/grafana/grafana/pull/71225
+func (d *DashboardStore) deleteResourcePermissions(sess *db.Session, orgID int64, resourceScope string) error {
+	// retrieve all permissions for the resource scope and org id
+	var permissionIDs []int64
+	err := sess.SQL("SELECT permission.id FROM permission INNER JOIN role ON permission.role_id = role.id WHERE permission.scope = ? AND role.org_id = ?", resourceScope, orgID).Find(&permissionIDs)
+	if err != nil {
+		return err
+	}
+
+	if len(permissionIDs) == 0 {
+		return nil
+	}
+
+	// delete the permissions
+	_, err = sess.In("id", permissionIDs).Delete(&ac.Permission{})
+	return err
 }
 
 func createEntityEvent(dashboard *models.Dashboard, eventType store.EntityEventType) *store.EntityEvent {


### PR DESCRIPTION
This is a backport of https://github.com/grafana/grafana/pull/71225/files

User permission is deleted unintentionally [sc-102539]
https://app.shortcut.com/soracom/story/102539/user-permission-is-deleted-unintentionally-by-removing-the-same-uid-dashboard-in-a-different-org