### PR TITLE
Added alert regarding the LINE Notify API EOL.

### DIFF
--- a/pkg/services/ngalert/notifier/channels_config/available_channels.go
+++ b/pkg/services/ngalert/notifier/channels_config/available_channels.go
@@ -948,6 +948,7 @@ func GetAvailableNotifiers() []*NotifierPlugin {
 			Name:        "LINE",
 			Description: "Send notifications to LINE notify",
 			Heading:     "LINE notify settings",
+			Alert:       "Due to the EOL of the LINE Notify API, LINE alerting will stop working after March 31, 2025. Please consider using another contact point.",
 			Options: []NotifierOption{
 				{
 					Label:        "Token",

--- a/pkg/services/ngalert/notifier/channels_config/plugin.go
+++ b/pkg/services/ngalert/notifier/channels_config/plugin.go
@@ -7,6 +7,7 @@ type NotifierPlugin struct {
 	Heading     string           `json:"heading"`
 	Description string           `json:"description"`
 	Info        string           `json:"info"`
+	Alert       string           `json:"alert"`
 	Options     []NotifierOption `json:"options"`
 }
 

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -151,6 +151,11 @@ export function ChannelSubForm<R extends ChannelValues>({
       </div>
       {notifier && (
         <div className={styles.innerContent}>
+          {notifier.alert !== '' && (
+            <Alert title="" severity="warning">
+              {notifier.alert}
+            </Alert>
+          )}
           <ChannelOptions<R>
             defaultValues={defaultValues}
             selectedChannelOptions={mandatoryOptions?.length ? mandatoryOptions! : optionalOptions!}

--- a/public/app/types/alerting.ts
+++ b/public/app/types/alerting.ts
@@ -75,6 +75,7 @@ export interface NotifierDTO {
   heading: string;
   options: NotificationChannelOption[];
   info?: string;
+  alert?: string;
   secure?: boolean;
 }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c03bc139-5841-488f-9782-e34d607b02bb)

Adds EOL warning message to LINE notifier configuration.

See: https://notify-bot.line.me/closing-announce