### PR TITLE
Customize dashboard initialization template

### DIFF
--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -280,13 +280,13 @@ export function getNewDashboardModelData(urlFolderId?: string, panelType?: strin
             datasource: {
               type: "harvest-backend-datasource"
             },
-            definition: "groups",
+            definition: "resource_types",
             hide: 0,
             includeAll: false,
             multi: false,
-            name: "groups",
+            name: "resource_types",
             options: [],
-            query: "groups",
+            query: "resource_types",
             refresh: 1,
             regex: "",
             skipUrlSync: false,
@@ -298,13 +298,13 @@ export function getNewDashboardModelData(urlFolderId?: string, panelType?: strin
             datasource: {
               type: "harvest-backend-datasource"
             },
-            definition: "resource_types",
+            definition: "groups",
             hide: 0,
             includeAll: false,
             multi: false,
-            name: "resource_types",
+            name: "groups",
             options: [],
-            query: "resource_types",
+            query: "groups",
             refresh: 1,
             regex: "",
             skipUrlSync: false,

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -280,13 +280,13 @@ export function getNewDashboardModelData(urlFolderId?: string, panelType?: strin
             datasource: {
               type: "harvest-backend-datasource"
             },
-            definition: "resource_types",
+            definition: "groups",
             hide: 0,
             includeAll: false,
             multi: false,
-            name: "resource_types",
+            name: "groups",
             options: [],
-            query: "resource_types",
+            query: "groups",
             refresh: 1,
             regex: "",
             skipUrlSync: false,
@@ -298,13 +298,13 @@ export function getNewDashboardModelData(urlFolderId?: string, panelType?: strin
             datasource: {
               type: "harvest-backend-datasource"
             },
-            definition: "groups",
+            definition: "resource_types",
             hide: 0,
             includeAll: false,
             multi: false,
-            name: "groups",
+            name: "resource_types",
             options: [],
-            query: "groups",
+            query: "resource_types",
             refresh: 1,
             regex: "",
             skipUrlSync: false,

--- a/public/app/features/dashboard/state/initDashboard.ts
+++ b/public/app/features/dashboard/state/initDashboard.ts
@@ -273,6 +273,82 @@ export function getNewDashboardModelData(urlFolderId?: string, panelType?: strin
           title: 'Panel Title',
         },
       ],
+      templating: {
+        list: [
+          {
+            current: {},
+            datasource: {
+              type: "harvest-backend-datasource"
+            },
+            definition: "resource_types",
+            hide: 0,
+            includeAll: false,
+            multi: false,
+            name: "resource_types",
+            options: [],
+            query: "resource_types",
+            refresh: 1,
+            regex: "",
+            skipUrlSync: false,
+            sort: 0,
+            type: "query"
+          },
+          {
+            current: {},
+            datasource: {
+              type: "harvest-backend-datasource"
+            },
+            definition: "groups",
+            hide: 0,
+            includeAll: false,
+            multi: false,
+            name: "groups",
+            options: [],
+            query: "groups",
+            refresh: 1,
+            regex: "",
+            skipUrlSync: false,
+            sort: 0,
+            type: "query"
+          },
+          {
+            current: {},
+            datasource: {
+              type: "harvest-backend-datasource"
+            },
+            definition: "$resource_types?group=$groups",
+            hide: 0,
+            includeAll: true,
+            multi: true,
+            name: "resources",
+            options: [],
+            query: "$resource_types?group=$groups",
+            refresh: 1,
+            regex: "",
+            skipUrlSync: false,
+            sort: 0,
+            type: "query"
+          },
+          {
+            current: {},
+            datasource: {
+              type: "harvest-backend-datasource"
+            },
+            definition: "$resource_types||$resources",
+            hide: 0,
+            includeAll: false,
+            multi: true,
+            name: "properties",
+            options: [],
+            query: "$resource_types||$resources",
+            refresh: 1,
+            regex: "",
+            skipUrlSync: false,
+            sort: 0,
+            type: "query"
+          }
+        ],
+      },
     },
   };
 


### PR DESCRIPTION
This modifies the initial new dashboard model so that our template variables get injected into every dashboard that is created. This obviates the need for our customers to each create their own template variables for relatively common queries.