### PR TITLE
soracom-v11.6.x/make-csv-joinbyfield-default

### DIFF
--- a/public/app/features/inspector/InspectDataTab.tsx
+++ b/public/app/features/inspector/InspectDataTab.tsx
@@ -56,7 +56,7 @@ export class InspectDataTab extends PureComponent<Props, State> {
     super(props);
 
     this.state = {
-      selectedDataFrame: 0,
+      selectedDataFrame: DataTransformerID.joinByField,
       dataFrameIndex: 0,
       transformId: DataTransformerID.noop,
       transformationOptions: buildTransformationOptions(),


### PR DESCRIPTION
Makes "Series joined by time" the default option when downloading CSV data from a dashboard panel.
See: https://github.com/soracom/grafana/pull/18

Based on the merge-base from main for Grafana 11.6.2.

![image](https://github.com/user-attachments/assets/25a365f3-7d84-4aa7-8932-c13df2eab362)
