### PR TITLE
soracom-v11.6.x/add-lagoon-settings

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -577,7 +577,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 				{Action: dashboards.ActionDashboardsPublicWrite, Scope: dashboards.ScopeDashboardsAll},
 			},
 		},
-		Grants: []string{"Admin"},
+		Grants: []string{string(org.RoleEditor)},
 	}
 
 	featuremgmtReaderRole := ac.RoleRegistration{

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	dashboardsnapshot "github.com/grafana/grafana/pkg/apis/dashboardsnapshot/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/lagoon"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -69,6 +70,12 @@ func (hs *HTTPServer) GetSharingOptions(c *contextmodel.ReqContext) {
 // 403: forbiddenError
 // 500: internalServerError
 func (hs *HTTPServer) CreateDashboardSnapshot(c *contextmodel.ReqContext) {
+	// Check if the organization's plan allows snapshots
+	if !lagoon.IsProPlan(c.SignedInUser.GetOrgName()) {
+		c.JsonApiErr(http.StatusForbidden, "Dashboard snapshots are not available on your current plan", nil)
+		return
+	}
+
 	cmd := dashboardsnapshots.CreateDashboardSnapshotCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		c.JsonApiErr(http.StatusBadRequest, "bad request data", err)
@@ -266,6 +273,12 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *contextmodel.ReqContext) respon
 func (hs *HTTPServer) SearchDashboardSnapshots(c *contextmodel.ReqContext) response.Response {
 	if !hs.Cfg.SnapshotEnabled {
 		c.JsonApiErr(http.StatusForbidden, "Dashboard Snapshots are disabled", nil)
+		return nil
+	}
+
+	// Check if the organization's plan allows snapshots
+	if !lagoon.IsProPlan(c.SignedInUser.GetOrgName()) {
+		c.JsonApiErr(http.StatusForbidden, "Dashboard snapshots are not available on your current plan", nil)
 		return nil
 	}
 

--- a/pkg/expr/commands.go
+++ b/pkg/expr/commands.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +16,18 @@ import (
 	"github.com/grafana/grafana/pkg/expr/mathexp"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
+
+var ResampleMaxPoints = 2500
+
+func init() {
+	if os.Getenv("LAGOON_RESAMPLE_MAX_POINTS") != "" {
+		rmpstring := os.Getenv("LAGOON_RESAMPLE_MAX_POINTS")
+		rmp, err := strconv.Atoi(rmpstring)
+		if err == nil {
+			ResampleMaxPoints = rmp
+		}
+	}
+}
 
 // Command is an interface for all expression commands.
 type Command interface {
@@ -227,6 +241,14 @@ func NewResampleCommand(refID, rawWindow, varToResample string, downsampler math
 	if err != nil {
 		return nil, fmt.Errorf(`failed to parse resample "window" duration field %q: %w`, window, err)
 	}
+
+	// lets try to limit the window/interval to a reasonable value
+	backendTimeRange := tr.AbsoluteTime(time.Now())
+	newSeriesLength := int(float64(backendTimeRange.To.Sub(backendTimeRange.From).Nanoseconds()) / float64(window.Nanoseconds()))
+	if newSeriesLength > ResampleMaxPoints {
+		return nil, fmt.Errorf(`resample "window" duration field %q is too low for the selected time range. %d points required but only %d allowed`, rawWindow, newSeriesLength, ResampleMaxPoints)
+	}
+
 	return &ResampleCommand{
 		Window:        window,
 		VarToResample: varToResample,

--- a/pkg/lagoon/lagoon.go
+++ b/pkg/lagoon/lagoon.go
@@ -1,0 +1,127 @@
+package lagoon
+
+import (
+	"context"
+	"crypto/md5"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+var (
+	lagoonLogger = log.New("lagoon")
+)
+
+// Plan is the Lagoon plan level
+type Plan string
+
+const (
+	// PlanMaker is the standard paid plan
+	PlanMaker Plan = "MAKER"
+	// PlanPro is for premium users
+	PlanPro Plan = "PRO"
+	// PlanFree is the free level
+	PlanFree Plan = "FREE"
+)
+
+// GetPlan returns the Lagoon plan the current org is on
+func GetPlan(orgservice org.Service, ctx context.Context, orgID int64) Plan {
+	query := org.GetOrgByIDQuery{ID: orgID}
+	org, err := orgservice.GetByID(ctx, &query)
+
+	if err != nil {
+		lagoonLogger.Warn("Failed to get Org ", "orgID", orgID, "error", err)
+		return PlanFree
+	}
+
+	return GetPlanFromOrgName(org.Name)
+
+}
+
+// GetPlanFromOrgName parses the orgname and determines through some magic code
+// what plan the customer is on
+func GetPlanFromOrgName(orgName string) Plan {
+	if strings.HasSuffix(orgName, "-"+string(PlanFree)) {
+		return PlanFree
+	}
+	if strings.HasSuffix(orgName, "-"+string(PlanPro)) {
+		return PlanPro
+	}
+	return PlanMaker
+}
+
+// AlertFrequencyForOrg returns the fastest possible refresh rate for alert evaluation
+func AlertFrequencyForPlan(plan Plan) int64 {
+
+	switch plan {
+	case PlanFree:
+		return 60
+	case PlanMaker:
+		return 30
+	case PlanPro:
+		return 5
+	}
+
+	// Just in case something weird happened.
+	return 60
+}
+
+// PublicDashboardsEnabledForPlan returns true if they are
+func PublicDashboardsEnabledForPlan(plan Plan) bool {
+	return plan == PlanPro
+}
+
+func IsFreePlan(orgName string) bool {
+	return strings.HasSuffix(orgName, "-"+string(PlanFree))
+}
+
+func IsProPlan(orgName string) bool {
+	return strings.HasSuffix(orgName, "-"+string(PlanPro))
+}
+
+func IsMakerPlan(orgName string) bool {
+	if IsProPlan(orgName) || IsFreePlan(orgName) {
+		return false
+	}
+
+	//if it isn't an empty string then it is good
+	return len(orgName) > 0
+}
+
+func HashWithOrgAccessKey(dsService datasources.DataSourceService, ctx context.Context, orgID int64, hashme string) (string, error) {
+
+	ak, err := GetOrgAccessKey(dsService, ctx, orgID)
+
+	if err != nil {
+		return "", err
+	}
+
+	ak = hashme + ak
+	hbytes := []byte(ak)
+	return fmt.Sprintf("%x", md5.Sum(hbytes)), nil
+
+}
+
+// This returns the first harvest access key it finds for the Org
+func GetOrgAccessKey(dsService datasources.DataSourceService, ctx context.Context, orgID int64) (string, error) {
+	query := datasources.GetDataSourcesQuery{OrgID: orgID, DataSourceLimit: 5}
+
+	dsList, err := dsService.GetDataSources(ctx, &query)
+	if err != nil {
+		return "", err
+	}
+
+	for _, ds := range dsList {
+
+		if (ds.Type == "soracom-harvest-datasource" || ds.Type == "harvest-backend-datasource") && len(ds.User) > 0 {
+			return ds.User, nil
+		}
+
+	}
+
+	return "", errors.New("could not find access key")
+}

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/lagoon"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apikey"
 	"github.com/grafana/grafana/pkg/services/authn"
@@ -289,7 +290,7 @@ func (s *ServiceImpl) getProfileNode(c *contextmodel.ReqContext) *navtree.NavLin
 		Text: "Notification history", Id: "profile/notifications", Url: s.cfg.AppSubURL + "/profile/notifications", Icon: "bell",
 	})
 
-	if s.cfg.AddChangePasswordLink() {
+	if c.SignedInUser.IsGrafanaAdmin && s.cfg.AddChangePasswordLink() {
 		children = append(children, &navtree.NavLink{
 			Text: "Change password", Id: "profile/password", Url: s.cfg.AppSubURL + "/profile/password",
 			Icon: "lock",
@@ -374,7 +375,7 @@ func (s *ServiceImpl) buildDashboardNavLinks(c *contextmodel.ReqContext) []*navt
 			})
 		}
 
-		if s.cfg.SnapshotEnabled && hasAccess(ac.EvalPermission(dashboards.ActionSnapshotsRead)) {
+		if s.cfg.SnapshotEnabled && hasAccess(ac.EvalPermission(dashboards.ActionSnapshotsRead)) && lagoon.IsProPlan(c.OrgName) {
 			dashboardChildNavs = append(dashboardChildNavs, &navtree.NavLink{
 				Text:     "Snapshots",
 				SubTitle: "Interactive, publicly available, point-in-time representations of dashboards",

--- a/pkg/services/ngalert/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol.go
@@ -61,10 +61,12 @@ var (
 					Action: accesscontrol.ActionAlertingRuleDelete,
 					Scope:  dashboards.ScopeFoldersAll,
 				},
+				/* Commented out to make rebasing easier in the future
 				{
 					Action: accesscontrol.ActionAlertingRuleExternalWrite,
 					Scope:  datasources.ScopeAll,
 				},
+				*/
 				{
 					Action: accesscontrol.ActionAlertingSilencesWrite,
 					Scope:  dashboards.ScopeFoldersAll,

--- a/pkg/services/notifications/notifications.go
+++ b/pkg/services/notifications/notifications.go
@@ -199,7 +199,27 @@ func __dangerouslyInjectHTML(s string) template.HTML {
 	return template.HTML(s)
 }
 
+// removeDefaultEmail just prevents any emails being sent to the default
+// example@email.com address
+func removeDefaultEmail(emails []string) []string {
+
+	filtered := []string{}
+
+	for _, email := range emails {
+		if !strings.Contains(email, "example@email.com") {
+			filtered = append(filtered, email)
+		}
+	}
+
+	return filtered
+}
+
 func (ns *NotificationService) SendEmailCommandHandlerSync(ctx context.Context, cmd *SendEmailCommandSync) error {
+	cmd.To = removeDefaultEmail(cmd.To)
+	if len(cmd.To) == 0 {
+		return nil //silently drop emails that were only to the default email
+	}
+
 	message, err := ns.buildEmailMessage(&SendEmailCommand{
 		Data:             cmd.Data,
 		Info:             cmd.Info,

--- a/pkg/services/publicdashboards/api/api.go
+++ b/pkg/services/publicdashboards/api/api.go
@@ -9,12 +9,14 @@ import (
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/lagoon"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	. "github.com/grafana/grafana/pkg/services/publicdashboards/models"
 	"github.com/grafana/grafana/pkg/services/publicdashboards/validation"
@@ -31,6 +33,7 @@ type Api struct {
 	features      featuremgmt.FeatureToggles
 	license       licensing.Licensing
 	log           log.Logger
+	orgService    org.Service
 	routeRegister routing.RouteRegister
 }
 
@@ -42,6 +45,7 @@ func ProvideApi(
 	md publicdashboards.Middleware,
 	cfg *setting.Cfg,
 	license licensing.Licensing,
+	orgService org.Service,
 ) *Api {
 	api := &Api{
 		PublicDashboardService: pd,
@@ -51,6 +55,7 @@ func ProvideApi(
 		features:               features,
 		license:                license,
 		log:                    log.New("publicdashboards.api"),
+		orgService:             orgService,
 		routeRegister:          rr,
 	}
 
@@ -60,6 +65,15 @@ func ProvideApi(
 	}
 
 	return api
+}
+
+// checkPlanPermission verifies if the current organization's plan allows public dashboards
+func (api *Api) checkPlanPermission(ctx context.Context, orgID int64) error {
+	plan := lagoon.GetPlan(api.orgService, ctx, orgID)
+	if !lagoon.PublicDashboardsEnabledForPlan(plan) {
+		return ErrPublicDashboardFeatureDisabled.Errorf("Public dashboards are not available on your current plan")
+	}
+	return nil
 }
 
 // RegisterAPIEndpoints Registers Endpoints on Grafana Router
@@ -179,6 +193,11 @@ func (api *Api) GetPublicDashboard(c *contextmodel.ReqContext) response.Response
 // 403: forbiddenPublicError
 // 500: internalServerPublicError
 func (api *Api) CreatePublicDashboard(c *contextmodel.ReqContext) response.Response {
+	// Check if the organization's plan allows public dashboards
+	if err := api.checkPlanPermission(c.Req.Context(), c.SignedInUser.GetOrgID()); err != nil {
+		return response.Err(err)
+	}
+
 	// exit if we don't have a valid dashboardUid
 	dashboardUid := web.Params(c.Req)[":dashboardUid"]
 	if !validation.IsValidShortUID(dashboardUid) {
@@ -233,6 +252,11 @@ func (api *Api) CreatePublicDashboard(c *contextmodel.ReqContext) response.Respo
 // 403: forbiddenPublicError
 // 500: internalServerPublicError
 func (api *Api) UpdatePublicDashboard(c *contextmodel.ReqContext) response.Response {
+	// Check if the organization's plan allows public dashboards
+	if err := api.checkPlanPermission(c.Req.Context(), c.SignedInUser.GetOrgID()); err != nil {
+		return response.Err(err)
+	}
+
 	// exit if we don't have a valid dashboardUid
 	dashboardUid := web.Params(c.Req)[":dashboardUid"]
 	if !validation.IsValidShortUID(dashboardUid) {

--- a/pkg/services/publicdashboards/models/errors.go
+++ b/pkg/services/publicdashboards/models/errors.go
@@ -24,5 +24,6 @@ var (
 	ErrPublicDashboardUidExists            = errutil.BadRequest("publicdashboards.uidExists", errutil.WithPublicMessage("Dashboard Uid already exists"))
 	ErrPublicDashboardAccessTokenExists    = errutil.BadRequest("publicdashboards.accessTokenExists", errutil.WithPublicMessage("Dashboard Access Token already exists"))
 
-	ErrPublicDashboardNotEnabled = errutil.Forbidden("publicdashboards.notEnabled", errutil.WithPublicMessage("Dashboard paused"))
+	ErrPublicDashboardNotEnabled       = errutil.Forbidden("publicdashboards.notEnabled", errutil.WithPublicMessage("Dashboard paused"))
+	ErrPublicDashboardFeatureDisabled = errutil.Forbidden("publicdashboards.featureDisabled", errutil.WithPublicMessage("Public dashboards feature is disabled"))
 )

--- a/pkg/services/quota/quotaimpl/quota.go
+++ b/pkg/services/quota/quotaimpl/quota.go
@@ -230,7 +230,11 @@ func (s *service) CheckQuotaReached(ctx context.Context, targetSrv quota.TargetS
 			if !ok {
 				return false, quota.ErrUsageFoundForTarget.Errorf("no usage for target:%s", t)
 			}
-			if u >= limit {
+			if t == "ngalert:alert_rule:org" {
+				if u > limit {
+					return true, nil
+				}
+			} else if u >= limit {
 				return true, nil
 			}
 		}

--- a/public/app/core/components/AccessControl/AddPermission.tsx
+++ b/public/app/core/components/AccessControl/AddPermission.tsx
@@ -100,6 +100,7 @@ export const AddPermission = ({
             <Select
               aria-label={'Built-in role picker'}
               options={Object.values(OrgRole)
+                .filter((e) => e !== 'Admin')
                 .filter((r) => r !== OrgRole.None)
                 .map((r) => ({ value: r, label: r }))}
               onChange={(r) => setBuiltinRole(r.value || '')}

--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -88,6 +88,10 @@ export const Permissions = ({
   };
 
   const onRemove = (item: ResourcePermission) => {
+    if (!okToChangeOrRemove(item, '')) {
+      alert('Cannot remove last Admin');
+      return;
+    }
     let promise: Promise<void> | null = null;
     if (item.userUid) {
       promise = setUserPermission(resource, resourceId, item.userUid, EMPTY_PERMISSION);
@@ -104,6 +108,10 @@ export const Permissions = ({
 
   const onChange = (item: ResourcePermission, permission: string) => {
     console.log('onChange', item, permission);
+    if (!okToChangeOrRemove(item, permission)) {
+      alert('Cannot remove last Admin');
+      return;
+    }
     if (item.permission === permission) {
       return;
     }
@@ -114,6 +122,22 @@ export const Permissions = ({
     } else if (item.builtInRole) {
       onAdd({ permission, builtInRole: item.builtInRole, target: PermissionTarget.BuiltInRole });
     }
+  };
+
+  const okToChangeOrRemove = (item: ResourcePermission, permission = '') => {
+    let numAdmins = 0;
+    items.forEach((itm: ResourcePermission) => {
+      if (itm.permission === 'Admin') {
+        numAdmins++;
+      }
+    });
+    if (numAdmins > 1) {
+      return true;
+    }
+    if (item.permission === 'Admin' && permission !== 'Admin') {
+      return false;
+    }
+    return true;
   };
 
   const teams = useMemo(

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -124,10 +124,12 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
         },
       });
 
+      const operatorId = config.bootData.user.orgName || '';
       if (
         contextSrv.isSignedIn &&
         config.snapshotEnabled &&
-        contextSrv.hasPermission(AccessControlAction.SnapshotsCreate)
+        contextSrv.hasPermission(AccessControlAction.SnapshotsCreate) &&
+        operatorId.endsWith('-PRO')
       ) {
         subMenu.push({
           text: t('share-panel.menu.share-snapshot-title', 'Share snapshot'),

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -52,6 +52,8 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
 
   // Panel share
   if (config.featureToggles.newDashboardSharingComponent) {
+    const operatorId = config.bootData.user.orgName || '';
+
     keybindings.addBinding({
       key: 'p u',
       onTrigger: withFocusedPanel(scene, async (vizPanel: VizPanel) => {
@@ -78,7 +80,8 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     if (
       contextSrv.isSignedIn &&
       config.snapshotEnabled &&
-      contextSrv.hasPermission(AccessControlAction.SnapshotsCreate)
+      contextSrv.hasPermission(AccessControlAction.SnapshotsCreate) &&
+      operatorId.endsWith('-PRO')
     ) {
       keybindings.addBinding({
         key: 'p s',

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
@@ -46,6 +46,7 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
 
   const buildMenuItems = useCallback(() => {
     const menuItems: ShareDrawerMenuItem[] = [];
+    const operatorId = config.bootData.user.orgName || '';
 
     menuItems.push({
       shareId: shareDashboardType.link,
@@ -61,7 +62,7 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
       testId: newShareButtonSelector.shareExternally,
       icon: 'share-alt',
       label: t('share-dashboard.menu.share-externally-title', 'Share externally'),
-      renderCondition: !panel && isPublicDashboardsEnabled(),
+      renderCondition: !panel && isPublicDashboardsEnabled() && operatorId.endsWith('-PRO'),
       onClick: () => {
         onMenuItemClick(shareDashboardType.publicDashboard);
       },
@@ -75,7 +76,8 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
       renderCondition:
         contextSrv.isSignedIn &&
         config.snapshotEnabled &&
-        contextSrv.hasPermission(AccessControlAction.SnapshotsCreate),
+        contextSrv.hasPermission(AccessControlAction.SnapshotsCreate) &&
+        operatorId.endsWith('-PRO'),
       onClick: () => {
         onMenuItemClick(shareDashboardType.snapshot);
       },

--- a/public/app/features/dashboard-scene/sharing/ShareModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareModal.tsx
@@ -59,10 +59,13 @@ export class ShareModal extends SceneObjectBase<ShareModalState> implements Moda
       tabs.push(new ShareExportTab({ modalRef }));
     }
 
+    const operatorId = config.bootData.user.orgName || '';
+
     if (
       contextSrv.isSignedIn &&
       config.snapshotEnabled &&
-      contextSrv.hasPermission(AccessControlAction.SnapshotsCreate)
+      contextSrv.hasPermission(AccessControlAction.SnapshotsCreate) &&
+      operatorId.endsWith('-PRO')
     ) {
       tabs.push(new ShareSnapshotTab({ panelRef, dashboardRef: dashboard.getRef(), modalRef }));
     }

--- a/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ShareModal.tsx
@@ -34,11 +34,13 @@ export function addPanelShareTab(tab: ShareModalTabModel) {
 function getTabs(canEditDashboard: boolean, panel?: PanelModel, activeTab?: string) {
   const linkLabel = t('share-modal.tab-title.link', 'Link');
   const tabs: ShareModalTabModel[] = [{ label: linkLabel, value: shareDashboardType.link, component: ShareLink }];
+  const operatorId = config.bootData.user.orgName || '';
 
   if (
     contextSrv.isSignedIn &&
     config.snapshotEnabled &&
-    contextSrv.hasPermission(AccessControlAction.SnapshotsCreate)
+    contextSrv.hasPermission(AccessControlAction.SnapshotsCreate) &&
+    operatorId.endsWith('-PRO')
   ) {
     const snapshotLabel = t('share-modal.tab-title.snapshot', 'Snapshot');
     tabs.push({ label: snapshotLabel, value: shareDashboardType.snapshot, component: ShareSnapshot });

--- a/public/app/features/profile/UserProfileEditForm.tsx
+++ b/public/app/features/profile/UserProfileEditForm.tsx
@@ -20,6 +20,11 @@ export const UserProfileEditForm = ({ user, isSavingUser, updateProfile }: Props
     updateProfile(data);
   };
 
+  // This disables Profile editing for non-admin users (name, password, etc)
+  if (!user || !user.isGrafanaAdmin) {
+    return null;
+  }
+
   // check if authLabels is longer than 0 otherwise false
   const isExternalUser: boolean = (user && user.isExternal) ?? false;
   const authSource = isExternalUser && user && user.authLabels ? user.authLabels[0] : '';


### PR DESCRIPTION
Restricts publlic dashboard and snapshot creation based on plan
Enables public dashboard creation for Editorrrrrs
Adds maximum refresh rates per plan on front end
Hides menus depending on plan
See: https://github.com/soracom/grafana/pull/12