### PR TITLE
soracom-v11.6.x/add-admin-user-filtering

### DIFF
--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -170,18 +170,14 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *contextmodel.ReqContext)
 		})
 	}
 
-	if !c.SignedInUser.IsGrafanaAdmin {
-		result = filterAdminUsers(result)
-	}
-
 	return response.JSON(http.StatusOK, result)
 }
 
-func filterAdminUsers(inDTOs []*dtos.UserLookupDTO) []*dtos.UserLookupDTO {
+func filterAdminUsers(inDTOs []*org.OrgUserDTO) []*org.OrgUserDTO {
 
-	outDTOs := make([]*dtos.UserLookupDTO, 0)
+	outDTOs := make([]*org.OrgUserDTO, 0)
 	for _, dto := range inDTOs {
-		if isSoracomAdminUser(dto.Login) {
+		if isSoracomAdminUser(dto.Login) || dto.Role == "Admin" {
 			continue
 		}
 		outDTOs = append(outDTOs, dto)
@@ -373,6 +369,10 @@ func (hs *HTTPServer) searchOrgUsersHelper(c *contextmodel.ReqContext, query *or
 			filteredUsers[i].AuthLabels = []string{login.GetAuthProviderLabel(module)}
 			filteredUsers[i].IsExternallySynced = hs.isExternallySynced(hs.Cfg, module)
 		}
+	}
+
+	if !c.SignedInUser.GetIsGrafanaAdmin() {
+		filteredUsers = filterAdminUsers(filteredUsers)
 	}
 
 	result.OrgUsers = filteredUsers

--- a/pkg/api/org_users.go
+++ b/pkg/api/org_users.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/response"
@@ -168,7 +170,36 @@ func (hs *HTTPServer) GetOrgUsersForCurrentOrgLookup(c *contextmodel.ReqContext)
 		})
 	}
 
+	if !c.SignedInUser.IsGrafanaAdmin {
+		result = filterAdminUsers(result)
+	}
+
 	return response.JSON(http.StatusOK, result)
+}
+
+func filterAdminUsers(inDTOs []*dtos.UserLookupDTO) []*dtos.UserLookupDTO {
+
+	outDTOs := make([]*dtos.UserLookupDTO, 0)
+	for _, dto := range inDTOs {
+		if isSoracomAdminUser(dto.Login) {
+			continue
+		}
+		outDTOs = append(outDTOs, dto)
+	}
+	return outDTOs
+}
+
+var adminUsers = os.Getenv("LAGOON_ADMIN_USERNAMES")
+
+func isSoracomAdminUser(user string) bool {
+	users := strings.Split(adminUsers, ",")
+
+	for _, adminName := range users {
+		if user == adminName {
+			return true
+		}
+	}
+	return false
 }
 
 // swagger:route GET /orgs/{org_id}/users orgs getOrgUsers


### PR DESCRIPTION
Hides presence of Admin user from APIs when called by a non-Admin user.

See https://github.com/soracom/grafana/pull/11