### PR TITLE
soracom-v11.6.x/add-image-link

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -371,6 +371,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Put("/", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsWrite)), routing.Wrap(hs.UpdateOrg))
 			orgsRoute.Put("/address", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsWrite)), routing.Wrap(hs.UpdateOrgAddress))
 			orgsRoute.Delete("/", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsDelete)), routing.Wrap(hs.DeleteOrgByID))
+			orgsRoute.Get("/image/link", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.GetLogoUploadLink))
 			orgsRoute.Get("/users", requestmeta.SetOwner(requestmeta.TeamAuth), authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.GetOrgUsers))
 			orgsRoute.Get("/users/search", requestmeta.SetOwner(requestmeta.TeamAuth), authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.SearchOrgUsers))
 			orgsRoute.Post("/users", requestmeta.SetOwner(requestmeta.TeamAuth), authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), routing.Wrap(hs.AddOrgUser))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -371,7 +371,7 @@ func (hs *HTTPServer) registerRoutes() {
 			orgsRoute.Put("/", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsWrite)), routing.Wrap(hs.UpdateOrg))
 			orgsRoute.Put("/address", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsWrite)), routing.Wrap(hs.UpdateOrgAddress))
 			orgsRoute.Delete("/", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsDelete)), routing.Wrap(hs.DeleteOrgByID))
-			orgsRoute.Get("/image/link", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.GetLogoUploadLink))
+			orgsRoute.Get("/image/link", authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgsWrite)), routing.Wrap(hs.GetLogoUploadLink))
 			orgsRoute.Get("/users", requestmeta.SetOwner(requestmeta.TeamAuth), authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.GetOrgUsers))
 			orgsRoute.Get("/users/search", requestmeta.SetOwner(requestmeta.TeamAuth), authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersRead)), routing.Wrap(hs.SearchOrgUsers))
 			orgsRoute.Post("/users", requestmeta.SetOwner(requestmeta.TeamAuth), authorizeInOrg(ac.UseOrgFromContextParams, ac.EvalPermission(ac.ActionOrgUsersAdd, ac.ScopeUsersAll)), routing.Wrap(hs.AddOrgUser))

--- a/pkg/api/images.go
+++ b/pkg/api/images.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+var ImageLinkerUrl = os.Getenv("IMAGE_LINKER_URL")
+var ImageLinkerKey = os.Getenv("IMAGE_LINKER_KEY")
+
+func hmacSHA256(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func generateSignature(key string, signType string, orgName string, signTime string) string {
+	// String to sign is something like "LagoonLogo:My Org:156465484894"
+	signature := hmacSHA256([]byte(key), []byte(signType+":"+orgName+":"+signTime))
+	// Convert the signature into something readable
+	signatureStr := fmt.Sprintf("%x", signature)
+
+	return signatureStr
+}
+
+// GetLogoUploadLink GET /api/orgs/images/link
+func (hs *HTTPServer) GetLogoUploadLink(c *contextmodel.ReqContext) response.Response {
+	query := org.GetOrgByIDQuery{ID: c.OrgID}
+
+	res, err := hs.orgService.GetByID(c.Req.Context(), &query)
+	if err != nil {
+		if errors.Is(err, org.ErrOrgNotFound) {
+			return response.Error(http.StatusNotFound, "Organization not found", err)
+		}
+		return response.Error(http.StatusInternalServerError, "Failed to get organization", err)
+	}
+
+	orga := res
+
+	linkerURL := ImageLinkerUrl
+	signingKey := ImageLinkerKey
+	signatureType := "LagoonLogo"
+
+	if len(linkerURL) == 0 {
+		return response.Error(500, "Image Linker URL error", errors.New("setting.ImageLinkerUrl is empty"))
+	}
+	if len(signingKey) == 0 {
+		return response.Error(500, "Image Linker Signing error", errors.New("setting.ImageLinkerKey is empty"))
+	}
+
+	orgName := orga.Name
+
+	if !strings.HasSuffix(orgName, "-PRO") {
+		return response.Error(500, "api.authenticationError", errors.New("organisation doesn't have PRO suffix"))
+	}
+
+	signTime := fmt.Sprintf("%v", time.Now().Unix())
+	signatureStr := generateSignature(signingKey, signatureType, orgName, signTime)
+
+	req, _ := http.NewRequest("GET", linkerURL, nil)
+
+	q := req.URL.Query()
+	q.Add("type", signatureType)
+	q.Add("auth", signatureStr)
+	q.Add("id", orgName)
+	q.Add("time", signTime)
+	req.URL.RawQuery = q.Encode()
+
+	fmt.Println(req.URL.String())
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return response.Error(500, "api.authenticationError", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return response.Error(500, "org.organizationNotFound", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+
+	if err != nil {
+		return response.Error(500, "api.authenticationError", err)
+	}
+
+	return response.JSON(200, body)
+}

--- a/pkg/api/images.go
+++ b/pkg/api/images.go
@@ -8,12 +8,14 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/web"
 )
 
 var ImageLinkerUrl = os.Getenv("IMAGE_LINKER_URL")
@@ -36,7 +38,12 @@ func generateSignature(key string, signType string, orgName string, signTime str
 
 // GetLogoUploadLink GET /api/orgs/images/link
 func (hs *HTTPServer) GetLogoUploadLink(c *contextmodel.ReqContext) response.Response {
-	query := org.GetOrgByIDQuery{ID: c.OrgID}
+	orgId, err := strconv.ParseInt(web.Params(c.Req)[":orgId"], 10, 64)
+	if err != nil {
+		return response.Error(http.StatusBadRequest, "orgId is invalid", err)
+	}
+
+	query := org.GetOrgByIDQuery{ID: orgId}
 
 	res, err := hs.orgService.GetByID(c.Req.Context(), &query)
 	if err != nil {


### PR DESCRIPTION
Adds the /api/orgs/:orgid/image/link API endpoint for PRO users to upload organization logos

See https://github.com/soracom/grafana/pull/16