### PR TITLE
soracom-v11.6.x/disable-alerts-with-label

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -463,7 +463,7 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 				query.ResultFoldersTitles[folder.Uid] = folder.Title
 			}
 		}
-		fmt.Println("Alerts found:", len(rules), " Folders:", len(folders))
+		st.Logger.Info("Alerts found for processing", "numAlerts", len(rules), "numFolders", len(folders))
 		return nil
 	})
 }

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -855,10 +855,6 @@ func (st DBstore) GetAlertRulesForScheduling(ctx context.Context, query *ngmodel
 			}
 		}
 		st.Logger.Info("Alerts found for processing", "numAlerts", len(query.ResultRules), "numFolders", len(query.ResultFoldersTitles))
-
-		resultRulesJson, _ := json.Marshal(query.ResultRules)
-		resultFoldersJson, _ := json.Marshal(query.ResultFoldersTitles)
-		st.Logger.Info("Debug alert info:", "alertInfo", string(resultRulesJson), "folders", string(resultFoldersJson))
 		return nil
 	})
 }


### PR DESCRIPTION
This rebases "Add ability to disable alert execution with label" to the 11.6.x merge-base. Adding a label `ALERT_DISABLED` to an alert rule stops it from executing.

See https://github.com/soracom/grafana/pull/14