### PR TITLE
soracom-v11.6.x/regex-meta-flag

### DIFF
--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -401,24 +401,25 @@ describe('soracomMetricNamesToVariableValues', () => {
   ];
 
   it.each`
-    variableRegEx                                                                   | expected        | expectErr
-    ${''}                                                                           | ${metricsNames} | ${false}
-    ${'/unknown/'}                                                                  | ${[]}           | ${false}
-    ${'/unknown/g'}                                                                 | ${[]}           | ${false}
-    ${'text/unknown/'}                                                              | ${[]}           | ${false}
-    ${'value/unknown/g'}                                                            | ${[]}           | ${false}
-    ${'text/.*shogo.*/'}                                                            | ${metricsNames} | ${false}
-    ${'TEXT/.*shogo.*/'}                                                            | ${metricsNames} | ${false}
-    ${'text/.*sim.*/'}                                                              | ${expected1}    | ${false}
-    ${'value/.*shogo.*/'}                                                           | ${[]}           | ${false}
-    ${'VALUE/.*shogo.*/'}                                                           | ${[]}           | ${false}
-    ${'value/^d-.*/'}                                                               | ${expected2}    | ${false}
-    ${'value/^999999088738969.*/'}                                                  | ${expected1}    | ${false}
-    ${'value/(999999088738969)/'}                                                   | ${expected1}    | ${false}
-    ${'/(999999088738969)/'}                                                        | ${expected1}    | ${false}
-    ${'/(d-bv172aeaukdipr6kdt9a)|(d-a616m91nq27llu552gfc)|d-a0m1nk44uebhra1e7196/'} | ${expected2}    | ${false}
-    ${'asdf//'}                                                                     | ${[]}           | ${true}
-    ${'asdf/'}                                                                      | ${[]}           | ${true}
+    variableRegEx                                                               | expected        | expectErr
+    ${''}                                                                       | ${metricsNames} | ${false}
+    ${'/unknown/'}                                                              | ${[]}           | ${false}
+    ${'/unknown/g'}                                                             | ${[]}           | ${false}
+    ${'name/unknown/'}                                                          | ${[]}           | ${false}
+    ${'id/unknown/'}                                                            | ${[]}           | ${false}
+    ${'name/.*shogo.*/'}                                                        | ${metricsNames} | ${false}
+    ${'NAME/.*shogo.*/'}                                                        | ${metricsNames} | ${false}
+    ${'name/.*sim.*/'}                                                          | ${expected1}    | ${false}
+    ${'name/shogo_arc_sim/'}                                                    | ${expected1}    | ${false}
+    ${'id/.*shogo.*/'}                                                          | ${[]}           | ${false}
+    ${'ID/.*shogo.*/'}                                                          | ${[]}           | ${false}
+    ${'id/^d-.*/'}                                                              | ${expected2}    | ${false}
+    ${'id/^999999088738969.*/'}                                                 | ${expected1}    | ${false}
+    ${'id/999999088738969/'}                                                    | ${expected1}    | ${false}
+    ${'/999999088738969/'}                                                      | ${expected1}    | ${false}
+    ${'/d-bv172aeaukdipr6kdt9a|d-a616m91nq27llu552gfc|d-a0m1nk44uebhra1e7196/'} | ${expected2}    | ${false}
+    ${'asdf//'}                                                                 | ${[]}           | ${true}
+    ${'asdf/'}                                                                  | ${[]}           | ${true}
   `(
     'when called with variableRegEx:$variableRegEx then it return correct options',
     ({ variableRegEx, expected, expectErr }) => {
@@ -426,8 +427,8 @@ describe('soracomMetricNamesToVariableValues', () => {
         const result = metricNamesToVariableValues(variableRegEx, VariableSort.disabled, metricsNames);
         expect(result).toEqual(expected);
       } catch (e) {
-        if (expectErr) {
-          expect(e).toBeTruthy();
+        if (!expectErr) {
+          throw e;
         }
       }
     }

--- a/public/app/features/variables/query/reducer.test.ts
+++ b/public/app/features/variables/query/reducer.test.ts
@@ -379,6 +379,61 @@ describe('metricNamesToVariableValues', () => {
   });
 });
 
+describe('soracomMetricNamesToVariableValues', () => {
+  const item = (_text: string, _value: string) => ({ text: _text, value: _value, selected: false });
+  const metricsNames = [
+    item('shogo : lagoon : breaker :', 'd-bv172aeaukdipr6kdt9a'),
+    item(`shogo"''"""'\"''""''"::':;':'::shogo:;;shogo:;sho:;;;:"shogo"\"\"\\"""breaker`, 'd-a616m91nq27llu552gfc'),
+    item('shogo_test_device_normal', 'd-a0m1nk44uebhra1e7196'),
+    item('shogo_arc_sim', '999999088738969'),
+  ];
+
+  const expected1 = [{ value: '999999088738969', text: 'shogo_arc_sim', selected: false }];
+
+  const expected2 = [
+    { value: 'd-bv172aeaukdipr6kdt9a', text: 'shogo : lagoon : breaker :', selected: false },
+    {
+      value: 'd-a616m91nq27llu552gfc',
+      text: `shogo"''"""'\"''""''"::':;':'::shogo:;;shogo:;sho:;;;:"shogo"\"\"\\"""breaker`,
+      selected: false,
+    },
+    { value: 'd-a0m1nk44uebhra1e7196', text: 'shogo_test_device_normal', selected: false },
+  ];
+
+  it.each`
+    variableRegEx                                                                   | expected        | expectErr
+    ${''}                                                                           | ${metricsNames} | ${false}
+    ${'/unknown/'}                                                                  | ${[]}           | ${false}
+    ${'/unknown/g'}                                                                 | ${[]}           | ${false}
+    ${'text/unknown/'}                                                              | ${[]}           | ${false}
+    ${'value/unknown/g'}                                                            | ${[]}           | ${false}
+    ${'text/.*shogo.*/'}                                                            | ${metricsNames} | ${false}
+    ${'TEXT/.*shogo.*/'}                                                            | ${metricsNames} | ${false}
+    ${'text/.*sim.*/'}                                                              | ${expected1}    | ${false}
+    ${'value/.*shogo.*/'}                                                           | ${[]}           | ${false}
+    ${'VALUE/.*shogo.*/'}                                                           | ${[]}           | ${false}
+    ${'value/^d-.*/'}                                                               | ${expected2}    | ${false}
+    ${'value/^999999088738969.*/'}                                                  | ${expected1}    | ${false}
+    ${'value/(999999088738969)/'}                                                   | ${expected1}    | ${false}
+    ${'/(999999088738969)/'}                                                        | ${expected1}    | ${false}
+    ${'/(d-bv172aeaukdipr6kdt9a)|(d-a616m91nq27llu552gfc)|d-a0m1nk44uebhra1e7196/'} | ${expected2}    | ${false}
+    ${'asdf//'}                                                                     | ${[]}           | ${true}
+    ${'asdf/'}                                                                      | ${[]}           | ${true}
+  `(
+    'when called with variableRegEx:$variableRegEx then it return correct options',
+    ({ variableRegEx, expected, expectErr }) => {
+      try {
+        const result = metricNamesToVariableValues(variableRegEx, VariableSort.disabled, metricsNames);
+        expect(result).toEqual(expected);
+      } catch (e) {
+        if (expectErr) {
+          expect(e).toBeTruthy();
+        }
+      }
+    }
+  );
+});
+
 function createMetric(value: string) {
   return {
     text: value,

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -16,18 +16,18 @@ import { initialVariablesState, VariablePayload, VariablesState } from '../state
 import { initialVariableModelState } from '../types';
 
 enum MetaFlag {
-  text = 'text',
-  value = 'value',
+  name = 'name',
+  id = 'id',
   none = '',
 }
 
 // I don't particularly like this function, but keyof typeof causes betterer eslint to get angry
 const stringToMetaFlag = (value: string): MetaFlag => {
   switch (value) {
-    case MetaFlag.text:
-      return MetaFlag.text;
-    case MetaFlag.value:
-      return MetaFlag.value;
+    case MetaFlag.name:
+      return MetaFlag.name;
+    case MetaFlag.id:
+      return MetaFlag.id;
     case MetaFlag.none:
       return MetaFlag.none;
     default:
@@ -168,10 +168,10 @@ export const metricNamesToVariableValues = (variableRegEx: string, sort: Variabl
     if (regex) {
       let matches;
       switch (metaFlag) {
-        case MetaFlag.text:
+        case MetaFlag.name:
           matches = getAllMatches(text, regex);
           break;
-        case MetaFlag.value: //Fallthrough - default grafana behavior is matching against value
+        case MetaFlag.id: //Fallthrough - default grafana behavior is matching against value
         case MetaFlag.none:
         default:
           matches = getAllMatches(value, regex);

--- a/public/app/features/variables/query/reducer.ts
+++ b/public/app/features/variables/query/reducer.ts
@@ -15,6 +15,26 @@ import { getInstanceState } from '../state/selectors';
 import { initialVariablesState, VariablePayload, VariablesState } from '../state/types';
 import { initialVariableModelState } from '../types';
 
+enum MetaFlag {
+  text = 'text',
+  value = 'value',
+  none = '',
+}
+
+// I don't particularly like this function, but keyof typeof causes betterer eslint to get angry
+const stringToMetaFlag = (value: string): MetaFlag => {
+  switch (value) {
+    case MetaFlag.text:
+      return MetaFlag.text;
+    case MetaFlag.value:
+      return MetaFlag.value;
+    case MetaFlag.none:
+      return MetaFlag.none;
+    default:
+      throw new Error(`${value} is not a valid meta flag.`);
+  }
+};
+
 interface VariableOptionsUpdate {
   templatedRegex: string;
   results: MetricFindValue[];
@@ -100,12 +120,36 @@ const getAllMatches = (str: string, regex: RegExp): RegExpExecArray[] => {
   return results;
 };
 
+const stringToMetaFlagAndRegex = (variableRegEx: string): [MetaFlag, RegExp] => {
+  const REGEX_CHAR = '/';
+
+  // variableRegEx has no metafield and is only a regex string
+  if (variableRegEx[0] === REGEX_CHAR) {
+    return [MetaFlag.none, stringToJsRegex(variableRegEx)];
+  }
+
+  // variableRegEx doesn't include / and is maybe just a basic string
+  if (!variableRegEx.includes(REGEX_CHAR)) {
+    return [MetaFlag.none, stringToJsRegex(variableRegEx)];
+  }
+
+  const regexStartIdx = variableRegEx.indexOf(REGEX_CHAR);
+
+  const metaString = variableRegEx.slice(0, regexStartIdx).toLowerCase();
+  const metaFlag = stringToMetaFlag(metaString);
+
+  const extractedRegexString = variableRegEx.slice(regexStartIdx);
+
+  return [metaFlag, stringToJsRegex(extractedRegexString)];
+};
+
 export const metricNamesToVariableValues = (variableRegEx: string, sort: VariableSort, metricNames: any[]) => {
   let regex;
+  let metaFlag = MetaFlag.none;
   let options: VariableOption[] = [];
 
   if (variableRegEx) {
-    regex = stringToJsRegex(variableRegEx);
+    [metaFlag, regex] = stringToMetaFlagAndRegex(variableRegEx);
   }
 
   for (let i = 0; i < metricNames.length; i++) {
@@ -122,7 +166,18 @@ export const metricNamesToVariableValues = (variableRegEx: string, sort: Variabl
     }
 
     if (regex) {
-      const matches = getAllMatches(value, regex);
+      let matches;
+      switch (metaFlag) {
+        case MetaFlag.text:
+          matches = getAllMatches(text, regex);
+          break;
+        case MetaFlag.value: //Fallthrough - default grafana behavior is matching against value
+        case MetaFlag.none:
+        default:
+          matches = getAllMatches(value, regex);
+          break;
+      }
+
       if (!matches.length) {
         continue;
       }


### PR DESCRIPTION
Rebase of https://github.com/soracom/grafana/pull/25

Adds the ability to apply a metaflag prefix to regex filters when defining query variable filters.