### PR TITLE
soracom-v11.6.x/clarify-delete-vs-discard-distinction

### DIFF
--- a/public/app/core/components/FormPrompt/FormPrompt.tsx
+++ b/public/app/core/components/FormPrompt/FormPrompt.tsx
@@ -111,7 +111,7 @@ const UnsavedChangesModal = ({ onDiscard, onBackToForm, isOpen }: UnsavedChanges
         <Button variant="secondary" onClick={onBackToForm} fill="outline">
           <Trans i18nKey="form-prompt.continue-button">Continue editing</Trans>
         </Button>
-        <Button variant="destructive" onClick={onDiscard}>
+        <Button variant="destructive" onClick={onDiscard} fill="outline">
           <Trans i18nKey="form-prompt.discard-button">Discard unsaved changes</Trans>
         </Button>
       </Modal.ButtonRow>

--- a/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
@@ -69,7 +69,8 @@ export const useDeleteModal = (redirectToListView = false): DeleteModalHook => {
       <ConfirmModal
         isOpen={Boolean(ruleToDelete)}
         title="Delete rule"
-        body="Deleting this rule will permanently remove it from your alert rule list. Are you sure you want to delete this rule?"
+        body="Deleting this rule will permanently remove it from your alert rule list. Are you sure you want to delete this rule? Type DELETE to confirm."
+        confirmationText="DELETE"
         confirmText="Yes, delete"
         icon="exclamation-triangle"
         onConfirm={deleteRule}

--- a/public/app/features/dashboard-scene/panel-edit/SaveLibraryVizPanelModal.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/SaveLibraryVizPanelModal.tsx
@@ -89,7 +89,7 @@ export const SaveLibraryVizPanelModal = ({ libraryPanel, isUnsavedPrompt, onDism
             Cancel
           </Button>
           {isUnsavedPrompt && (
-            <Button variant="destructive" onClick={discardAndClose}>
+            <Button variant="destructive" onClick={discardAndClose} fill="outline">
               Discard
             </Button>
           )}

--- a/public/app/features/dashboard-scene/saving/DashboardPrompt.tsx
+++ b/public/app/features/dashboard-scene/saving/DashboardPrompt.tsx
@@ -134,7 +134,7 @@ export const UnsavedChangesModal = ({ onDiscard, onDismiss, onSaveDashboardClick
         <Button variant="secondary" onClick={onDismiss} fill="outline">
           Cancel
         </Button>
-        <Button variant="destructive" onClick={onDiscard}>
+        <Button variant="destructive" onClick={onDiscard} fill="outline">
           Discard
         </Button>
         <Button onClick={onSaveDashboardClick}>Save dashboard</Button>

--- a/public/app/features/dashboard/components/SaveDashboard/UnsavedChangesModal.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/UnsavedChangesModal.tsx
@@ -29,7 +29,7 @@ export const UnsavedChangesModal = ({ dashboard, onSaveSuccess, onDiscard, onDis
         <Button variant="secondary" onClick={onDismiss} fill="outline">
           Cancel
         </Button>
-        <Button variant="destructive" onClick={onDiscard}>
+        <Button variant="destructive" onClick={onDiscard} fill="outline">
           Discard
         </Button>
         <SaveDashboardButton dashboard={dashboard} onSaveSuccess={onSaveSuccess} />

--- a/public/app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal.tsx
@@ -99,7 +99,7 @@ export const SaveLibraryPanelModal = ({
             Cancel
           </Button>
           {isUnsavedPrompt && (
-            <Button variant="destructive" onClick={discardAndClose}>
+            <Button variant="destructive" onClick={discardAndClose} fill="outline">
               Discard
             </Button>
           )}


### PR DESCRIPTION
Effectively rebased https://github.com/soracom/grafana/pull/31 to the 11.6.x merge-base.

Changes Discard related actions in modals to use the outline style, and adds confirmation text to the alert rule deletion modal to prevent accidental deletion by customers. 

In response to https://soracom.productboard.com/entity-detail/features/28233360/detail